### PR TITLE
Some small edits to the Example in your readme

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,5 @@
 {
-    "python.pythonPath": "D:\\ProgramData\\Anaconda3\\python.exe",
+    "python.pythonPath": "C:\\ProgramData\\Anaconda3\\python.exe",
     "python.testing.unittestArgs": [
         "-v",
         "-s",

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This is a REST API implementation for Radiology Nuance PowerScribe 360 dictation
 The following will allow you to connect to PowerScribe 360 server and send custom field to the radiologist report.
 
 ```python
-from powerscribe import Powerscribe
+from powerscribe.Powerscribe import Powerscribe
 
 if __name__ == '__main__':
     url = 'http://ps360ServerName/RadPortal'
@@ -22,7 +22,7 @@ if __name__ == '__main__':
         if ps.sign_in(username, password):
             print("Signin successfully")
             if ps.set_custom_field(accession, field_name, field_value):
-                print(f"Sent field name {field_name} and value {field_value} into accession {accession})
+                print(f"Sent field name {field_name} and value {field_value} into accession {accession}")
             else:
                 print(f"Error sending field name {field_name} and value {field_value} into accession {accession}")
         else:


### PR DESCRIPTION
1. Changed the import to get around the type error below due to the function having the same name as the module

TypeError                                 Traceback (most recent call last)
<ipython-input-6-5947ccdb5253> in <module>
     10     field_value = "29997"
     11 
---> 12     with Powerscribe(url) as ps:
     13         if ps.sign_in(username, password):
     14             print("Signin successfully")

TypeError: 'module' object is not callable


2. Adding a missing closing quotation in the print statement